### PR TITLE
Fix the invariant of environment

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -69,6 +69,7 @@ impl Environment {
 
     pub fn incr_pc(&mut self, count: u64) {
         self.program_counter += count;
+        self.end_cycle = u64::max(self.end_cycle, self.program_counter);
     }
 }
 


### PR DESCRIPTION
One of the current environment invariants is `program_counter <= end_cycle`, but the implementation violates it. This PR fixes it.